### PR TITLE
WIP: Add support for page title and meta tags

### DIFF
--- a/lib/beacon/loader/page_module_loader.ex
+++ b/lib/beacon/loader/page_module_loader.ex
@@ -10,7 +10,7 @@ defmodule Beacon.Loader.PageModuleLoader do
 
     # Group function heads together to avoid compiler warnings
     functions =
-      for fun <- [&render_page/1, &layout_id_for_path/1],
+      for fun <- [&render_page/1, &dynamic_layout_data/1],
           page <- pages do
         fun.(page)
       end
@@ -51,9 +51,15 @@ defmodule Beacon.Loader.PageModuleLoader do
     """
   end
 
-  defp layout_id_for_path(%Page{path: path, layout_id: layout_id}) do
+  defp dynamic_layout_data(%Page{path: path, layout_id: layout_id}) do
+    # TODO: Add page_title and meta_tags to Page schema, and merge em in here
+
     """
-      def layout_id_for_path(#{path_to_args(path, "_")}), do: #{inspect(layout_id)}
+      def dynamic_layout_data(#{path_to_args(path, "_")}) do
+        %{
+          layout_id: #{inspect(layout_id)}
+        }
+      end
     """
   end
 

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -6,17 +6,17 @@ defmodule BeaconWeb.PageLive do
   def mount(%{"path" => path} = params, %{"beacon_site" => site}, socket) do
     live_data = Beacon.DataSource.live_data(site, path, Map.drop(params, ["path"]))
 
-    layout_id =
+    dynamic_layout_data =
       site
       |> Beacon.Loader.page_module_for_site()
-      |> Beacon.Loader.call_function_with_retry(:layout_id_for_path, [path])
+      |> Beacon.Loader.call_function_with_retry(:dynamic_layout_data, [path])
 
     socket =
       socket
       |> assign(:beacon_live_data, live_data)
       |> assign(:__live_path__, path)
       |> assign(:__page_update_available__, false)
-      |> assign(:__dynamic_layout_id__, layout_id)
+      |> assign(:__dynamic_layout_data__, dynamic_layout_data)
       |> assign(:__site__, site)
 
     socket =

--- a/lib/beacon_web/live/page_live.ex
+++ b/lib/beacon_web/live/page_live.ex
@@ -21,7 +21,7 @@ defmodule BeaconWeb.PageLive do
 
     socket =
       socket
-      |> push_event("meta", %{meta: BeaconWeb.LayoutView.meta_tags_unsafe(socket.assigns)})
+      |> push_event("meta", %{meta: BeaconWeb.LayoutView.meta_tags_unsafe(socket.assigns, dynamic_layout_data)})
       |> push_event("lang", %{lang: "en"})
 
     Beacon.PubSub.subscribe_page_update(site, path)

--- a/lib/beacon_web/views/dynamic_layout_view.ex
+++ b/lib/beacon_web/views/dynamic_layout_view.ex
@@ -7,7 +7,7 @@ defmodule BeaconWeb.DynamicLayoutView do
   # so we instruct Elixir to not warn if the dashboard route is missing.
   @compile {:no_warn_undefined, {Routes, :live_dashboard_path, 2}}
 
-  def render_layout(%{__dynamic_layout_id__: layout_id, __site__: site} = assigns) do
+  def render_layout(%{__dynamic_layout_data__: %{layout_id: layout_id}, __site__: site} = assigns) do
     module = Beacon.Loader.layout_module_for_site(site)
 
     Beacon.Loader.call_function_with_retry(module, :render, [layout_id, assigns])

--- a/lib/beacon_web/views/layout_view.ex
+++ b/lib/beacon_web/views/layout_view.ex
@@ -9,7 +9,7 @@ defmodule BeaconWeb.LayoutView do
 
   def page_title(%{layout_assigns: %{page_title: page_title}}), do: page_title
 
-  def page_title(%{__dynamic_layout_id__: layout_id, __site__: site}) do
+  def page_title(%{__dynamic_layout_data__: %{layout_id: layout_id}, __site__: site}) do
     %{title: title} = compiled_layout_assigns(site, layout_id)
     title
   end
@@ -20,7 +20,7 @@ defmodule BeaconWeb.LayoutView do
   end
 
   # for dynamic pages
-  def meta_tags(%{__dynamic_layout_id__: _, __site__: _} = assigns) do
+  def meta_tags(%{__dynamic_layout_data__: _, __site__: _} = assigns) do
     {:safe, meta_tags_unsafe(assigns)}
   end
 
@@ -47,10 +47,10 @@ defmodule BeaconWeb.LayoutView do
     compiled_meta_tags(assigns)
   end
 
-  def dynamic_layout?(%{__dynamic_layout_id__: _}), do: true
+  def dynamic_layout?(%{__dynamic_layout_data__: _}), do: true
   def dynamic_layout?(_), do: false
 
-  defp compiled_meta_tags(%{__dynamic_layout_id__: layout_id, __site__: site}) do
+  defp compiled_meta_tags(%{__dynamic_layout_data__: %{layout_id: layout_id}, __site__: site}) do
     %{meta_tags: compiled_meta_tags} = compiled_layout_assigns(site, layout_id)
     compiled_meta_tags
   end
@@ -61,7 +61,7 @@ defmodule BeaconWeb.LayoutView do
     Beacon.Loader.call_function_with_retry(module, :layout_assigns, [layout_id])
   end
 
-  def stylesheet_tag(%{__dynamic_layout_id__: _, __site__: site}) do
+  def stylesheet_tag(%{__dynamic_layout_data__: _, __site__: site}) do
     module = Beacon.Loader.stylesheet_module_for_site(site)
 
     stylesheet_tag = Beacon.Loader.call_function_with_retry(module, :render, [])
@@ -70,7 +70,7 @@ defmodule BeaconWeb.LayoutView do
 
   def stylesheet_tag(_), do: ""
 
-  def linked_stylesheets(%{__dynamic_layout_id__: _, __site__: _} = assigns) do
+  def linked_stylesheets(%{__dynamic_layout_data__: _, __site__: _} = assigns) do
     {:safe, linked_stylesheets_unsafe(assigns)}
   end
 
@@ -97,7 +97,7 @@ defmodule BeaconWeb.LayoutView do
     compiled_linked_stylesheets(assigns)
   end
 
-  defp compiled_linked_stylesheets(%{__dynamic_layout_id__: layout_id, __site__: site}) do
+  defp compiled_linked_stylesheets(%{__dynamic_layout_data__: %{layout_id: layout_id}, __site__: site}) do
     %{stylesheet_urls: compiled_linked_stylesheets} = compiled_layout_assigns(site, layout_id)
     compiled_linked_stylesheets
   end


### PR DESCRIPTION
Here is my initial thought about how we could add support for page titles and meta tags to the `Page` schema. That way, a layout could specify default values, and then the individual Pages could take precedence over that.

The idea here will be to add the page-specific info in the `:__dynamic_layout_data__` map, and then in the layout view have the logic to pluck that back out if it's specified.

The next step in a future PR would be to make this even MORE dynamic and add another layer with even higher precedence, by adding `page_title/3` and `meta_tags/3` callbacks to the `DataSource` behaviour.